### PR TITLE
Small fix for API response handling and authorization string encoding

### DIFF
--- a/vodafonem2m/vodafonem2m.py
+++ b/vodafonem2m/vodafonem2m.py
@@ -90,34 +90,19 @@ class VodafoneM2M:
         return self._send_message('get', '/m2m/v1/{}'.format(self.home))
 
     @staticmethod
-    def _handle_api_response(json_response):
+    def _handle_api_response(response):
         """
         Throw exceptions on errors from API.
 
-        :param json_response:
+        :param response:
         :return:
         """
-
-        if not json_response:
+        if not response:
             raise ValueError('Error getting data from the api, no data returned')
-        if "error" in json_response:
-            raise ValueError("Standard Error:: {} : {}".format(
-                json_response["error"], json_response["error_description"]))
-        elif "description" in json_response:
-            if "Service Error" in json_response['description']:
-                raise ValueError("Service Error:: {} : {}".format(
-                    json_response["id"], json_response["description"]))
-        else:
-            try:
-                codes = json_response[list(json_response.keys())[0]]['return']['returnCode']
-                if codes['majorReturnCode'] != '000' or codes['minorReturnCode'] != '0000':
-                    raise ValueError(
-                        "Return Code Error:: Major: {}, Minor: {}".format(
-                            codes['majorReturnCode'], codes['minorReturnCode'])
-                    )
-            except KeyError:
-                pass
-        return json_response
+
+        response.raise_for_status()
+
+        return response.json()
 
     def _send_message(self, method, endpoint, params=None, headers=None, data=None):
         """
@@ -136,4 +121,4 @@ class VodafoneM2M:
         url = self.url + endpoint
         r = self.session.request(method, url, data=data,
                                  params=params, headers=headers)
-        return self._handle_api_response(r.json())
+        return self._handle_api_response(r)

--- a/vodafonem2m/vodafonem2m.py
+++ b/vodafonem2m/vodafonem2m.py
@@ -7,7 +7,7 @@
 from datetime import datetime
 
 import requests
-
+import base64
 
 class VodafoneM2M:
     """

--- a/vodafonem2m/vodafonem2m.py
+++ b/vodafonem2m/vodafonem2m.py
@@ -48,9 +48,10 @@ class VodafoneM2M:
         :param password:
         :return:
         """
-        concat_string = "{}:{}".format(username, password)
+        concat_string = "{}:{}".format(username, password).encode('utf-8')
+        encoded_string = base64.standard_b64encode(concat_string).decode('utf-8')
         headers = {
-            'Authorization': "Basic " + base64.standard_b64encode(concat_string),
+            'Authorization': "Basic " + encoded_string,
             'Content-Type': "application/x-www-form-urlencoded",
             'Accept': "*/*",
             'Cache-Control': "no-cache",


### PR DESCRIPTION
I couldn't get the example code working and I noticed that the base64 library was not imported in the vodafonem2m module.

Having fixed this I found that there were some errors related to building the authorization string and concatenating it to headers. I added the necessary encoding and decoding.

Finally, the response handling did not seem to be working, so I replaced it with a call to the Response object's own error handling method.

With these changes I was able to run the example code without errors.